### PR TITLE
Removed legacy prettier option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
     "vetur.format.defaultFormatter.ts": "vscode-typescript",
     "vetur.format.defaultFormatter.html": "prettier",
     "vetur.format.options.tabSize": 4,
-    "prettier.tslintIntegration": true,
     "prettier.tabWidth": 4,
     "json.schemas": [
         {


### PR DESCRIPTION
Removed a legacy prettier extension option in .vscode/settings.json, that prevented prettier formatting
